### PR TITLE
fix: correct cricket term all-around -> all-round

### DIFF
--- a/TheTilt/public/goats.html
+++ b/TheTilt/public/goats.html
@@ -24,7 +24,7 @@
         <div class="tabs">
             <button class="tab active" data-section="match_batting">match batting</button>
             <button class="tab" data-section="match_bowling">match bowling</button>
-            <button class="tab" data-section="match_allround">match all-around</button>
+            <button class="tab" data-section="match_allround">match all-round</button>
             <button class="tab" data-section="season_batting">season batting</button>
             <button class="tab" data-section="season_bowling">season bowling</button>
             <button class="tab" data-section="match_batting_runs">match runs</button>


### PR DESCRIPTION
## Summary
- Fixed the cricket terminology typo in `TheTilt/public/goats.html` line 27
- Changed "match all-around" to "match all-round" (British English, consistent with the rest of the codebase)

## Fix
```html
<!-- Before -->
<button class="tab" data-section="match_allround">match all-around</button>

<!-- After -->
<button class="tab" data-section="match_allround">match all-round</button>
```

Closes #141